### PR TITLE
Start on improving error handeling and add crate docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0.33"
-proc-macro2 = "1.0.67"
-syn = {version="2.0.33", features=["full"]}
+proc-macro2 = "1.0.69"
+syn = {version="2.0.39", features=["full"]}
 pathdiff = "0.2.1"
-itertools = "0.11.0"
 proc-macro-error = "1.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ proc-macro2 = "1.0.67"
 syn = {version="2.0.33", features=["full"]}
 pathdiff = "0.2.1"
 itertools = "0.11.0"
+proc-macro-error = "1.0.4"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Test Each File
 
-[![github](https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github)](https://github.com/binary-banter/test-each-file)&ensp;[![crates-io](https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust)](https://crates.io/crates/test_each_file)&ensp;[![docs-rs](https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs)](https://docs.rs/test_each_file)
+[![github](https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github)](https://github.com/binary-banter/test-each-file)
+&ensp;[![crates-io](https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust)](https://crates.io/crates/test_each_file)
+&ensp;[![docs-rs](https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs)](https://docs.rs/test_each_file)
 
 Easily generate tests for files in a specified directory for comprehensive testing.
 
@@ -42,7 +44,7 @@ fn b() {
 
 mod extra {
     use super::*;
-    
+
     #[test]
     fn c() {
         test(include_str!("../resources/extra/c.txt"))
@@ -59,12 +61,14 @@ test_each_file! { in "./resources" as example => test }
 ```
 
 This will wrap the tests above in an additional `mod example { ... }`.
-This feature is useful when `test_each_file!` is used multiple times in a single file, to prevent that the generated tests have the same name.
+This feature is useful when `test_each_file!` is used multiple times in a single file, to prevent that the generated
+tests have the same name.
 
 ## File grouping
 
 Sometimes it may be preferable to write a test that takes the contents of multiple files as input.
-A common use-case for this is testing a function that performs a transformation from a given input (`.in` file) to an output (`.out` file).
+A common use-case for this is testing a function that performs a transformation from a given input (`.in` file) to an
+output (`.out` file).
 
 ```rust
 test_each_file! { for ["in", "out"] in "./resources" => test }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Test Each File
 
+[![github](https://img.shields.io/badge/github-8da0cb?style=for-the-badge&labelColor=555555&logo=github)](https://github.com/binary-banter/test-each-file)&ensp;[![crates-io](https://img.shields.io/badge/crates.io-fc8d62?style=for-the-badge&labelColor=555555&logo=rust)](https://crates.io/crates/test_each_file)&ensp;[![docs-rs](https://img.shields.io/badge/docs.rs-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs)](https://docs.rs/test_each_file)
+
 Easily generate tests for files in a specified directory for comprehensive testing.
 
 A simple example of the macro is shown below:
+
 ```rust
 test_each_file! { in "./resources" => test }
 
@@ -12,7 +15,8 @@ fn test(content: &str) {
 ```
 
 Given the following file structure:
-```
+
+```txt
 - resources
   - a.txt
   - b.txt
@@ -23,6 +27,7 @@ Given the following file structure:
 ```
 
 The macro expands to:
+
 ```rust
 #[test]
 fn a() {
@@ -48,6 +53,7 @@ mod extra {
 ## Generate submodule
 
 The tests can automatically be inserted into a module, by using the `as` keyword. For example:
+
 ```rust
 test_each_file! { in "./resources" as example => test }
 ```
@@ -70,7 +76,7 @@ fn test([input, output]: [&str; 2]) {
 
 Both the `.in` and `.out` files must exist and be located in the same directory, as demonstrated below:
 
-```
+```txt
 - resources
   - a.in
   - a.out
@@ -88,11 +94,13 @@ Note that `.in` and `.out` are just examples here - any number of unique extensi
 ## More examples
 
 The expression that is called on each file can also be a closure, for example:
+
 ```rust
 test_each_file! { in "./resources" => |c: &str| assert!(c.contains("Hello World")) }
 ```
 
 All the options above can be combined, for example:
+
 ```rust
 test_each_file! { for ["in", "out"] in "./resources" as example => |[a, b]: [&str; 2]| assert_eq!(a, b) }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,7 @@ impl Parse for ForEachFile {
         let path_span = path.span();
         let path = path.value();
 
-        let module = if input.peek(Token![as]) {
-            input.parse::<Token![as]>()?;
+        let module = if let Ok(_) = input.parse::<Token![as]>() {
             Some(input.parse::<Ident>()?)
         } else {
             None
@@ -150,6 +149,10 @@ fn generate_from_tree(tree: &Tree, parsed: &ForEachFile, stream: &mut TokenStrea
 #[proc_macro_error]
 pub fn test_each_file(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let parsed = parse_macro_input!(input as ForEachFile);
+
+    if !Path::new(&parsed.path).is_dir() {
+        abort!(parsed.path_span, "Given directory does not exist");
+    }
 
     let mut tokens = TokenStream::new();
     let files = Tree::new(parsed.path.as_ref(), !parsed.extensions.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 use pathdiff::diff_paths;
 use proc_macro2::{Ident, Span, TokenStream};
 use proc_macro_error::{abort, abort_call_site, proc_macro_error};
@@ -16,7 +17,7 @@ struct ForEachFile {
     module: Option<Ident>,
     function: Expr,
     extensions: Vec<String>,
-    extensions_span: Vec<Span>,
+    _extensions_span: Vec<Span>,
 }
 
 impl Parse for ForEachFile {
@@ -57,7 +58,7 @@ impl Parse for ForEachFile {
             module,
             function,
             extensions: extensions.unwrap_or_default(),
-            extensions_span: extensions_span.unwrap_or_default(),
+            _extensions_span: extensions_span.unwrap_or_default(),
         })
     }
 }
@@ -145,6 +146,9 @@ fn generate_from_tree(tree: &Tree, parsed: &ForEachFile, stream: &mut TokenStrea
     }
 }
 
+/// Easily generate tests for files in a specified directory for comprehensive testing.
+///
+/// See crate level documentation for details.
 #[proc_macro]
 #[proc_macro_error]
 pub fn test_each_file(input: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,10 +71,6 @@ struct Tree {
 
 impl Tree {
     fn new(base: &Path, ignore_extensions: bool) -> Self {
-        if !base.is_dir() {
-            abort_call_site!("Given directory is not a directory");
-        }
-
         let mut tree = Self::default();
         for entry in base.read_dir().unwrap() {
             let mut entry = entry.unwrap().path();


### PR DESCRIPTION
The following has been changed:
- `prefix` has been renamed to `module` to reflect more how it is used.
- With the crate '[proc-macro-error](https://crates.io/crates/proc-macro-error)' are some panic errors replaced with a 'compile-like' error.
   - this made it possible to show the error om the span (token's) where the error originated.
- To `test_each_file` macro is for now a simple doc added.
- Readme has been added as crate level doc
- Badges are added Readme