### PR TITLE
Create `test_each_path` analogue to `test_each_file`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_each_file"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jonathan Brouwer <jonathantbrouwer@gmail.com>", "Julia Dijkstra"]
 description = "Generates a test for each file in a specified directory."
 keywords = ["test", "proc-macro"]
@@ -10,6 +10,7 @@ repository = "https://github.com/binary-banter/test-each-file"
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 quote = "1.0.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,4 @@ proc-macro = true
 quote = "1.0.33"
 proc-macro2 = "1.0.69"
 syn = { version = "2.0.39", features = ["full"] }
-pathdiff = "0.2.1"
 proc-macro-error = "1.0.4"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ Both the `.in` and `.out` files must exist and be located in the same directory,
 
 Note that `.in` and `.out` are just examples here - any number of unique extensions can be given of arbitrary types.
 
+## Test each path
+
+A similar macro exists for passing all the paths in a given directory. This macro behaves identically to `test_each_file!`, 
+except that it passes the paths of the files rather than the contents. It is usually preferable to use `test_each_file!`,
+because it includes the files in the binary, whereas the paths still need to be there during run-time for `test_each_path!`.
+
+```rust
+test_each_path! { for ["in", "out"] in "./resources" => test }
+
+fn test([input, output]: [&Path; 2]) {
+    // Make assertions on the path of `input` and `output` here.
+}
+```
+
 ## More examples
 
 The expression that is called on each file can also be a closure, for example:

--- a/examples/readme/main.rs
+++ b/examples/readme/main.rs
@@ -2,24 +2,52 @@ fn main() {}
 
 #[cfg(test)]
 mod tests {
-    use test_each_file::test_each_file;
+    mod file {
+        use test_each_file::test_each_file;
 
-    fn simple_test(input: &str) {
-        assert!(input.split_whitespace().all(|n| n.parse::<usize>().is_ok()));
+        fn simple(input: &str) {
+            assert!(input.split_whitespace().all(|n| n.parse::<usize>().is_ok()));
+        }
+
+        fn complex([input, output]: [&str; 2]) {
+            assert_eq!(
+                input
+                    .split_whitespace()
+                    .map(|n| n.parse::<usize>().unwrap())
+                    .sum::<usize>(),
+                output.parse().unwrap()
+            )
+        }
+
+        test_each_file! { in "./examples/readme/resources_simple/" as simple => simple}
+        test_each_file! { for ["in", "out"] in "./examples/readme/resources_complex/" as complex => complex}
+        test_each_file! { in "./examples/readme/resources_simple/" as closure => |c: &str| assert!(c.contains(" ")) }
+        test_each_file! { for ["in", "out"] in "./examples/readme/resources_complex/" as example => |[a, b]: [&str; 2]| assert_ne!(a, b) }
     }
 
-    fn complex_test([input, output]: [&str; 2]) {
-        assert_eq!(
-            input
+    mod path {
+        use std::fs::read_to_string;
+        use test_each_file::test_each_path;
+
+        fn simple(input: &str) {
+            assert!(read_to_string(input)
+                .unwrap()
                 .split_whitespace()
-                .map(|n| n.parse::<usize>().unwrap())
-                .sum::<usize>(),
-            output.parse().unwrap()
-        )
-    }
+                .all(|n| n.parse::<usize>().is_ok()));
+        }
 
-    test_each_file! { in "./examples/readme/resources_simple/" as simple => simple_test}
-    test_each_file! { for ["in", "out"] in "./examples/readme/resources_complex/" as complex => complex_test}
-    test_each_file! { in "./examples/readme/resources_simple/" as closure => |c: &str| assert!(c.contains(" ")) }
-    test_each_file! { for ["in", "out"] in "./examples/readme/resources_complex/" as example => |[a, b]: [&str; 2]| assert_ne!(a, b) }
+        fn complex([input, output]: [&str; 2]) {
+            assert_eq!(
+                read_to_string(input)
+                    .unwrap()
+                    .split_whitespace()
+                    .map(|n| n.parse::<usize>().unwrap())
+                    .sum::<usize>(),
+                read_to_string(output).unwrap().parse().unwrap()
+            )
+        }
+
+        test_each_path! { in "./examples/readme/resources_simple/" as simple => simple}
+        test_each_path! { for ["in", "out"] in "./examples/readme/resources_complex/" as complex => complex}
+    }
 }

--- a/examples/readme/main.rs
+++ b/examples/readme/main.rs
@@ -27,16 +27,17 @@ mod tests {
 
     mod path {
         use std::fs::read_to_string;
+        use std::path::Path;
         use test_each_file::test_each_path;
 
-        fn simple(input: &str) {
+        fn simple(input: &Path) {
             assert!(read_to_string(input)
                 .unwrap()
                 .split_whitespace()
                 .all(|n| n.parse::<usize>().is_ok()));
         }
 
-        fn complex([input, output]: [&str; 2]) {
+        fn complex([input, output]: [&Path; 2]) {
             assert_eq!(
                 read_to_string(input)
                     .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,14 @@ use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{bracketed, parse_macro_input, Expr, LitStr, Token};
 
-struct ForEachArgs {
+struct TestEachArgs {
     path: LitStr,
     module: Option<Ident>,
     function: Expr,
     extensions: Vec<String>,
 }
 
-impl Parse for ForEachArgs {
+impl Parse for TestEachArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         // Optionally parse extensions if the keyword `for` is used. Aborts if none are given.
         let extensions = input
@@ -108,7 +108,7 @@ enum Type {
 
 fn generate_from_tree(
     tree: &Tree,
-    parsed: &ForEachArgs,
+    parsed: &TestEachArgs,
     stream: &mut TokenStream,
     invocation_type: &Type,
 ) {
@@ -123,7 +123,7 @@ fn generate_from_tree(
 
             match invocation_type {
                 Type::File => quote!(include_str!(#input)),
-                Type::Path => quote!(#input),
+                Type::Path => quote!(std::path::Path::new(#input)),
             }
         } else {
             let mut arguments = TokenStream::new();
@@ -134,7 +134,7 @@ fn generate_from_tree(
 
                 arguments.extend(match invocation_type {
                     Type::File => quote!(include_str!(#input),),
-                    Type::Path => quote!(#input,),
+                    Type::Path => quote!(std::path::Path::new(#input),),
                 });
             }
 
@@ -163,7 +163,7 @@ fn generate_from_tree(
 }
 
 fn test_each(input: proc_macro::TokenStream, invocation_type: &Type) -> proc_macro::TokenStream {
-    let parsed = parse_macro_input!(input as ForEachArgs);
+    let parsed = parse_macro_input!(input as TestEachArgs);
 
     if !Path::new(&parsed.path.value()).is_dir() {
         abort!(parsed.path.span(), "Given directory does not exist");


### PR DESCRIPTION
Sometimes it's useful to have the path instead of the contents of the file.