### PR TITLE
Sanitize and dedup file names for use as idents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ quote = "1.0.33"
 proc-macro2 = "1.0.69"
 syn = { version = "2.0.39", features = ["full"] }
 proc-macro-error = "1.0.4"
+unicode-ident = "1.0.12"


### PR DESCRIPTION
The file and directory names containing test cases are assumed to be unique and valid identifiers (after stripping the extension), but this is not always the case (e.g., if a name begins with a digit or contains a hyphen). Add a function for sanitizing identifiers, and prepend the relative index of the name to ensure uniqueness even when two names sanitize to the same result (e.g., `a-b` and `a_b`).