### PR TITLE
Support adding attributes to each test

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,14 @@ The expression that is called on each file can also be a closure, for example:
 test_each_file! { in "./resources" => |c: &str| assert!(c.contains("Hello World")) }
 ```
 
+Multiple attributes can optionally be applied to each test, for example:
+
+```rust
+test_each_file! { #[ignore, cfg(target_os = "linux")] in "./resources" => test }
+```
+
 All the options above can be combined, for example:
 
 ```rust
-test_each_file! { for ["in", "out"] in "./resources" as example => |[a, b]: [&str; 2]| assert_eq!(a, b) }
+test_each_file! { #[ignore, cfg(target_os = "linux")] for ["in", "out"] in "./resources" as example => |[a, b]: [&str; 2]| assert_eq!(a, b) }
 ```


### PR DESCRIPTION
Uses similar code to that which parses extensions.

My use case also requires async tests, but that should probably be a separate PR.

closes #9 