### PR TITLE
feat: implement ignoring tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,32 @@ fn test([input, output]: [&Path; 2]) {
 }
 ```
 
+## Ignoring specific tests
+
+You can selectively ignore tests based on file names using the `ignore` keyword.
+This is useful for tests that are slow, require external services, or should only be run explicitly.
+
+Provide a map of file names to ignore reasons:
+
+```rust
+test_each_path! { 
+    #[cfg(feature = "integration")]
+    for ["in", "out"] 
+    in "./tests/integration" 
+    as integration
+    => test 
+    ignore {
+        "slow" => "Load tests, ignored for taking two hours",
+        "external" => "Requires external services"
+    }
+}
+```
+
+This will add `#[ignore = "reason"]` to matching tests, allowing you to document why certain tests are ignored.
+The ignore patterns match against the tests' names.
+
+Ignored tests can be run explicitly with `cargo test -- --ignored`.
+
 ## More examples
 
 The expression that is called on each file can also be a closure, for example:

--- a/examples/readme/main.rs
+++ b/examples/readme/main.rs
@@ -74,4 +74,32 @@ mod tests {
 
         test_each_file! { #[tokio::test] async in "./examples/readme/resources_simple/" as simple => run }
     }
+
+    mod ignore {
+        use std::path::Path;
+        use test_each_file::{test_each_file, test_each_path};
+
+        fn test_path(_input: &Path) {}
+        async fn test_async(_input: &str) {}
+
+        test_each_path! {
+            in "./examples/readme/resources_simple"
+            as basic
+            => test_path
+            ignore: {
+                "a" => "Slow test"
+            }
+        }
+
+        test_each_file! {
+            #[tokio::test]
+            async
+            in "./examples/readme/resources_simple"
+            as with_async
+            => test_async
+            ignore {
+                "b" => "Requires setup"
+            }
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,14 +90,8 @@ impl IgnorePatterns {
     ///
     /// Returns Some(reason) if ignored, or None if not ignored
     fn should_ignore(&self, name: &str) -> Option<String> {
-        if let Some(stripped) = name.strip_prefix("r#") {
-            self.patterns
-                .get(stripped)
-                .cloned()
-                .or_else(|| self.patterns.get(name).cloned())
-        } else {
-            self.patterns.get(name).cloned()
-        }
+        let lookup_name = name.strip_prefix("r#").unwrap_or(name);
+        self.patterns.get(lookup_name).cloned()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::env;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -18,6 +18,7 @@ struct TestEachArgs {
     extensions: Vec<String>,
     attributes: Vec<Meta>,
     async_fn: Option<Async>,
+    ignore_patterns: IgnorePatterns,
 }
 
 macro_rules! abort {
@@ -30,6 +31,66 @@ macro_rules! abort_token_stream {
     ($span:expr, $message:expr) => {
         return syn::Error::new($span, $message).into_compile_error().into()
     };
+}
+
+#[derive(Default)]
+struct IgnorePatterns {
+    patterns: HashMap<String, String>,
+}
+
+impl Parse for IgnorePatterns {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if !input
+            .fork()
+            .parse::<Ident>()
+            .ok()
+            .is_some_and(|id| id == "ignore")
+        {
+            return Ok(IgnorePatterns::default());
+        }
+        let _: Ident = input.parse().unwrap();
+        
+        // Optional ":" separator
+        let _ = input.parse::<Token![:]>();
+
+        let content;
+        syn::braced!(content in input);
+
+        let mut patterns = HashMap::new();
+        while !content.is_empty() {
+            let key: LitStr = match content.parse() {
+                Ok(k) => k,
+                Err(e) => abort!(
+                    e.span(),
+                    "Expected a string literal for ignore pattern name."
+                ),
+            };
+
+            if let Err(e) = content.parse::<Token![=>]>() {
+                abort!(e.span(), "Expected `=>` after ignore pattern name.");
+            }
+
+            let reason: LitStr = match content.parse() {
+                Ok(r) => r,
+                Err(e) => abort!(e.span(), "Expected a string literal for ignore reason."),
+            };
+
+            patterns.insert(key.value(), reason.value());
+
+            // Optional comma
+            let _ = content.parse::<Token![,]>();
+        }
+
+        Ok(IgnorePatterns { patterns })
+    }
+}
+
+impl IgnorePatterns {
+    /// Check if a given name should be ignored
+    /// Returns Some(reason) if ignored, or None if not ignored
+    fn should_ignore(&self, name: &str) -> Option<String> {
+        self.patterns.get(name).cloned()
+    }
 }
 
 impl Parse for TestEachArgs {
@@ -107,6 +168,9 @@ impl Parse for TestEachArgs {
             Err(e) => abort!(e.span(), "Expected a function to call after `=>`."),
         };
 
+        // Optionally parse ignore patterns if the keyword `ignore` is used.
+        let ignore_patterns = IgnorePatterns::parse(input)?;
+
         Ok(Self {
             path,
             module,
@@ -114,14 +178,15 @@ impl Parse for TestEachArgs {
             extensions,
             attributes,
             async_fn,
+            ignore_patterns,
         })
     }
 }
 
 #[derive(Default)]
 struct Tree {
-    children: HashMap<PathBuf, Tree>,
-    here: HashSet<PathBuf>,
+    children: BTreeMap<PathBuf, Tree>,
+    here: BTreeSet<PathBuf>,
 }
 
 impl Tree {
@@ -267,6 +332,12 @@ fn generate_from_tree(
         for attribute in &parsed.attributes {
             stream.extend(quote! {
                 #[#attribute]
+            });
+        }
+
+        if let Some(reason) = parsed.ignore_patterns.should_ignore(&file_name.to_string()) {
+            stream.extend(quote! {
+                #[ignore = #reason]
             });
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ impl Parse for IgnorePatterns {
             return Ok(IgnorePatterns::default());
         }
         let _: Ident = input.parse().unwrap();
-        
+
         // Optional ":" separator
         let _ = input.parse::<Token![:]>();
 
@@ -87,9 +87,17 @@ impl Parse for IgnorePatterns {
 
 impl IgnorePatterns {
     /// Check if a given name should be ignored
+    ///
     /// Returns Some(reason) if ignored, or None if not ignored
     fn should_ignore(&self, name: &str) -> Option<String> {
-        self.patterns.get(name).cloned()
+        if let Some(stripped) = name.strip_prefix("r#") {
+            self.patterns
+                .get(stripped)
+                .cloned()
+                .or_else(|| self.patterns.get(name).cloned())
+        } else {
+            self.patterns.get(name).cloned()
+        }
     }
 }
 


### PR DESCRIPTION
This PR implements the following syntax:

```rust
test_each_path! { 
    #[cfg(feature = "integration")]
    for ["in", "out"] 
    in "./tests/integration" 
    as integration
    => test 
    ignore {
        "slow" => "Load tests, ignored for taking two hours",
        "external" => "Requires external services"
    }
}
```

Resolves https://github.com/binary-banter/test-each-file/issues/20

CC @nyurik